### PR TITLE
Clean README of LaTeX markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 ### Pregunta 1
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 2
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -19,7 +19,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 3
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -27,15 +27,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 4
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 5
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -45,13 +45,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 6
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 7
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -59,7 +59,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 8
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -67,15 +67,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 9
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 10
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -85,13 +85,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 11
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 12
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -99,7 +99,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 13
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -107,15 +107,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 14
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 15
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -125,13 +125,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 16
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 17
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -139,7 +139,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 18
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -147,15 +147,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 19
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 20
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -165,13 +165,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 21
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 22
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -179,7 +179,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 23
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -187,15 +187,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 24
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 25
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -205,13 +205,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 26
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 27
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -219,7 +219,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 28
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -227,15 +227,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 29
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 30
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -245,13 +245,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 31
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 32
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -259,7 +259,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 33
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -267,15 +267,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 34
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 35
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -285,13 +285,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 36
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 37
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -299,7 +299,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 38
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -307,15 +307,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 39
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 40
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -325,13 +325,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 41
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 42
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -339,7 +339,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 43
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -347,15 +347,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 44
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 45
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -365,13 +365,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 46
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 47
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -379,7 +379,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 48
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -387,15 +387,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 49
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 50
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -405,13 +405,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 51
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 52
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -419,7 +419,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 53
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -427,15 +427,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 54
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 55
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -445,13 +445,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 56
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 57
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -459,7 +459,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 58
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -467,15 +467,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 59
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 60
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -485,13 +485,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 61
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 62
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -499,7 +499,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 63
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -507,15 +507,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 64
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 65
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -525,13 +525,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 66
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 67
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -539,7 +539,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 68
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -547,15 +547,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 69
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 70
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -565,13 +565,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 71
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 72
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -579,7 +579,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 73
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -587,15 +587,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 74
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 75
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -605,13 +605,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 76
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 77
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -619,7 +619,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 78
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -627,15 +627,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 79
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 80
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -645,13 +645,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 81
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 82
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -659,7 +659,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 83
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -667,15 +667,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 84
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 85
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -685,13 +685,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 86
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 87
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -699,7 +699,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 88
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -707,15 +707,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 89
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 90
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -725,13 +725,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 91
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 92
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -739,7 +739,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 93
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -747,15 +747,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 94
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 95
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -765,13 +765,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 96
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 97
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -779,7 +779,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 98
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -787,15 +787,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 99
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 100
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -805,13 +805,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 101
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 102
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -819,7 +819,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 103
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -827,15 +827,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 104
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 105
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -845,13 +845,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 106
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 107
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -859,7 +859,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 108
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -867,15 +867,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 109
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 110
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -885,13 +885,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 111
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 112
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -899,7 +899,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 113
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -907,15 +907,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 114
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 115
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -925,13 +925,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 116
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 117
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -939,7 +939,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 118
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -947,15 +947,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 119
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 120
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -965,13 +965,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 121
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 122
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -979,7 +979,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 123
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -987,15 +987,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 124
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 125
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1005,13 +1005,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 126
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 127
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1019,7 +1019,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 128
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1027,15 +1027,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 129
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 130
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1045,13 +1045,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 131
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 132
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1059,7 +1059,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 133
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1067,15 +1067,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 134
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 135
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1085,13 +1085,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 136
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 137
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1099,7 +1099,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 138
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1107,15 +1107,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 139
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 140
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1125,13 +1125,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 141
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 142
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1139,7 +1139,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 143
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1147,15 +1147,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 144
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 145
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1165,13 +1165,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 146
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 147
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1179,7 +1179,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 148
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1187,15 +1187,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 149
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 150
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1205,13 +1205,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 151
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 152
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1219,7 +1219,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 153
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1227,15 +1227,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 154
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 155
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1245,13 +1245,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 156
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 157
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1259,7 +1259,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 158
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1267,15 +1267,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 159
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 160
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1285,13 +1285,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 161
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 162
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1299,7 +1299,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 163
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1307,15 +1307,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 164
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 165
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1325,13 +1325,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 166
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 167
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1339,7 +1339,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 168
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1347,15 +1347,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 169
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 170
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1365,13 +1365,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 171
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 172
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1379,7 +1379,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 173
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1387,15 +1387,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 174
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 175
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1405,13 +1405,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 176
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 177
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1419,7 +1419,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 178
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1427,15 +1427,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 179
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 180
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1445,13 +1445,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 181
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 182
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1459,7 +1459,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 183
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1467,15 +1467,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 184
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 185
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1485,13 +1485,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 186
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 187
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1499,7 +1499,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 188
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1507,15 +1507,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 189
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 190
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1525,13 +1525,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 191
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 192
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1539,7 +1539,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 193
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1547,15 +1547,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 194
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 195
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1565,13 +1565,13 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 ### Pregunta 196
 ¿Cuál de las siguientes afirmaciones es verdadera respecto a la aritmética de punteros en C++?
 
-- **A)** \texttt{*(ptr + 1)} incrementa el valor apuntado.
-- **B)** \texttt{ptr++} incrementa la dirección de memoria.
-- **C)** \texttt{ptr = &ptr + 1} es legal y segura.
-- **D)** \texttt{*ptr++} incrementa el puntero, no el valor.
+- **A)** *(ptr + 1) incrementa el valor apuntado.
+- **B)** ptr++ incrementa la dirección de memoria.
+- **C)** ptr = &ptr + 1 es legal y segura.
+- **D)** *ptr++ incrementa el puntero, no el valor.
 
 ### Pregunta 197
-Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \texttt{a} tras la ejecución?
+Dado el código: int a = 5; int* p = &a; *p = 10;, ¿qué valor tiene a tras la ejecución?
 
 - **A)** 5
 - **B)** 10
@@ -1579,7 +1579,7 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Error en compilación
 
 ### Pregunta 198
-¿Qué error produce el siguiente código? \texttt{int* p = new int[10]; delete p;}
+¿Qué error produce el siguiente código? int* p = new int[10]; delete p;
 
 - **A)** Ninguno
 - **B)** Pérdida de memoria
@@ -1587,15 +1587,15 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **D)** Comportamiento indefinido
 
 ### Pregunta 199
-¿Qué representa \texttt{&(*ptr)}?
+¿Qué representa &(*ptr)?
 
-- **A)** Dirección de \texttt{ptr}
-- **B)** Dirección original apuntada por \texttt{ptr}
+- **A)** Dirección de ptr
+- **B)** Dirección original apuntada por ptr
 - **C)** El valor apuntado
 - **D)** Dirección de un puntero
 
 ### Pregunta 200
-¿Cuál de estas líneas causa error? \texttt{int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;}
+¿Cuál de estas líneas causa error? int* p = nullptr; *nullptr = 10; int x = *p; int** q = &p;
 
 - **A)** A
 - **B)** B
@@ -1608,1398 +1608,1398 @@ Dado el código: \texttt{int a = 5; int* p = &a; *p = 10;}, ¿qué valor tiene \
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 2
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 3
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 4
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 5
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 6
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 7
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 8
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 9
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 10
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 11
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 12
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 13
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 14
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 15
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 16
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 17
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 18
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 19
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 20
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 21
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 22
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 23
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 24
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 25
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 26
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 27
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 28
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 29
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 30
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 31
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 32
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 33
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 34
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 35
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 36
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 37
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 38
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 39
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 40
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 41
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 42
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 43
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 44
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 45
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 46
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 47
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 48
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 49
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 50
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 51
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 52
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 53
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 54
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 55
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 56
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 57
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 58
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 59
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 60
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 61
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 62
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 63
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 64
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 65
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 66
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 67
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 68
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 69
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 70
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 71
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 72
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 73
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 74
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 75
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 76
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 77
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 78
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 79
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 80
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 81
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 82
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 83
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 84
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 85
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 86
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 87
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 88
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 89
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 90
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 91
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 92
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 93
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 94
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 95
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 96
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 97
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 98
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 99
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 100
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 101
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 102
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 103
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 104
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 105
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 106
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 107
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 108
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 109
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 110
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 111
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 112
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 113
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 114
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 115
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 116
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 117
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 118
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 119
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 120
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 121
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 122
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 123
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 124
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 125
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 126
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 127
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 128
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 129
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 130
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 131
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 132
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 133
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 134
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 135
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 136
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 137
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 138
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 139
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 140
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 141
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 142
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 143
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 144
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 145
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 146
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 147
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 148
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 149
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 150
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 151
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 152
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 153
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 154
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 155
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 156
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 157
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 158
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 159
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 160
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 161
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 162
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 163
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 164
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 165
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 166
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 167
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 168
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 169
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 170
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 171
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 172
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 173
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 174
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 175
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 176
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 177
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 178
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 179
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 180
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 181
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 182
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 183
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 184
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 185
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 186
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 187
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 188
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 189
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 190
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 191
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 192
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 193
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 194
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 195
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 196
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Aritmética de punteros
-- **Explicación:** \texttt{*ptr++} desreferencia y luego incrementa
+- **Explicación:** *ptr++ desreferencia y luego incrementa
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 197
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Conocimiento
 - **Concepto evaluado:** Asignación indirecta
-- **Explicación:** \texttt{*p = 10} modifica \texttt{a}
+- **Explicación:** *p = 10 modifica a
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 198
 - **Respuesta correcta:** D
 - **Nivel Bloom:** Análisis
 - **Concepto evaluado:** Gestión de memoria dinámica
-- **Explicación:** Debe usarse \texttt{delete[]} para arrays
+- **Explicación:** Debe usarse delete[] para arrays
 - **Puntuación:** 1.0 puntos
 
 ### Pregunta 199
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Comprensión
 - **Concepto evaluado:** Equivalencias básicas
-- **Explicación:** \texttt{&(*ptr)} revierte la desreferencia
+- **Explicación:** &(*ptr) revierte la desreferencia
 - **Puntuación:** 0.5 puntos
 
 ### Pregunta 200
 - **Respuesta correcta:** B
 - **Nivel Bloom:** Evaluación
 - **Concepto evaluado:** Uso de punteros nulos
-- **Explicación:** Desreferenciar \texttt{nullptr} causa error
+- **Explicación:** Desreferenciar nullptr causa error
 - **Puntuación:** 1.0 puntos


### PR DESCRIPTION
## Summary
- strip all `\texttt{...}` markup from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc6636914832d9a8932d86ceb6b08